### PR TITLE
Added arm32v7 to all images

### DIFF
--- a/install_armhf.yaml
+++ b/install_armhf.yaml
@@ -136,7 +136,7 @@ spec:
           value: "1000"
         - name: PGID
           value: "1000"
-        image: linuxserver/bazarr:arm32v6-latest
+        image: linuxserver/bazarr:arm32v7-latest
         name: bazarr
         ports:
         - containerPort: 6767
@@ -275,7 +275,7 @@ spec:
           value: "1000"
         - name: PGID
           value: "1000"
-        image: linuxserver/jackett:arm32v6-latest
+        image: linuxserver/jackett:arm32v7-latest
         name: jackett
         ports:
         - containerPort: 9117
@@ -337,7 +337,7 @@ spec:
           value: "1000"
         - name: PGID
           value: "1000"
-        image: linuxserver/radarr:arm32v6-latest
+        image: linuxserver/radarr:arm32v7-latest
         livenessProbe:
           exec:
             command:
@@ -435,7 +435,7 @@ spec:
           value: "1000"
         - name: PGID
           value: "1000"
-        image: linuxserver/sonarr:arm32v6-latest
+        image: linuxserver/sonarr:arm32v7-latest
         livenessProbe:
           exec:
             command:
@@ -533,7 +533,7 @@ spec:
           value: "1000"
         - name: PGID
           value: "1000"
-        image: linuxserver/transmission:arm32v6-latest
+        image: linuxserver/transmission:arm32v7-latest
         name: transmission
         ports:
         - containerPort: 9091


### PR DESCRIPTION
Hi,
First of all, super good initiative. Running this on K3S (Kubernetes) on Raspberry Pi's.
The setup works perfectly, it's just that the arm32v6 are not being maintained anymore.
Thus you won't get the latest version of e.g. Sonarr.
I did this minor change and it works perfectly on RPI 3 (running a cluster of 4 nodes)