### PR TITLE
Migrate to Ingress v1 API

### DIFF
--- a/base/ingress.yaml
+++ b/base/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: htpc
@@ -7,26 +7,44 @@ spec:
   - http:
       paths:
       - path: /
+        pathType: Exact
         backend:
-          serviceName: emby
-          servicePort: webui
+          service:
+            name: emby
+            port:
+              name: webui
       - path: /jackett
+        pathType: Exact
         backend:
-          serviceName: jackett
-          servicePort: webui
+          service:
+            name: jackett
+            port:
+              name: webui
       - path: /sonarr
+        pathType: Exact
         backend:
-          serviceName: sonarr
-          servicePort: webui
+          service:
+            name: sonarr
+            port:
+              name: webui
       - path: /radarr
+        pathType: Exact
         backend:
-          serviceName: radarr
-          servicePort: webui
+          service:
+            name: radarr
+            port:
+              name: webui
       - path: /bazarr
+        pathType: Exact
         backend:
-          serviceName: bazarr
-          servicePort: webui
+          service:
+            name: bazarr
+            port:
+              name: webui
       - path: /transmission
+        pathType: Exact
         backend:
-          serviceName: transmission
-          servicePort: webui
+          service:
+            name: transmission
+            port:
+              name: webui

--- a/install_armhf.yaml
+++ b/install_armhf.yaml
@@ -585,7 +585,7 @@ spec:
           type: DirectoryOrCreate
         name: htpc-home
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
@@ -597,26 +597,44 @@ spec:
   - http:
       paths:
       - backend:
-          serviceName: emby
-          servicePort: webui
+          service:
+            name: emby
+            port:
+              name: webui
         path: /
+        pathType: Exact
       - backend:
-          serviceName: jackett
-          servicePort: webui
+          service:
+            name: jackett
+            port:
+              name: webui
         path: /jackett
+        pathType: Exact
       - backend:
-          serviceName: sonarr
-          servicePort: webui
+          service:
+            name: sonarr
+            port:
+              name: webui
         path: /sonarr
+        pathType: Exact
       - backend:
-          serviceName: radarr
-          servicePort: webui
+          service:
+            name: radarr
+            port:
+              name: webui
         path: /radarr
+        pathType: Exact
       - backend:
-          serviceName: bazarr
-          servicePort: webui
+          service:
+            name: bazarr
+            port:
+              name: webui
         path: /bazarr
+        pathType: Exact
       - backend:
-          serviceName: transmission
-          servicePort: webui
+          service:
+            name: transmission
+            port:
+              name: webui
         path: /transmission
+        pathType: Exact

--- a/install_x86_64.yaml
+++ b/install_x86_64.yaml
@@ -585,7 +585,7 @@ spec:
           type: DirectoryOrCreate
         name: htpc-home
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
@@ -597,26 +597,44 @@ spec:
   - http:
       paths:
       - backend:
-          serviceName: emby
-          servicePort: webui
+          service:
+            name: emby
+            port:
+              name: webui
         path: /
+        pathType: Exact
       - backend:
-          serviceName: jackett
-          servicePort: webui
+          service:
+            name: jackett
+            port:
+              name: webui
         path: /jackett
+        pathType: Exact
       - backend:
-          serviceName: sonarr
-          servicePort: webui
+          service:
+            name: sonarr
+            port:
+              name: webui
         path: /sonarr
+        pathType: Exact
       - backend:
-          serviceName: radarr
-          servicePort: webui
+          service:
+            name: radarr
+            port:
+              name: webui
         path: /radarr
+        pathType: Exact
       - backend:
-          serviceName: bazarr
-          servicePort: webui
+          service:
+            name: bazarr
+            port:
+              name: webui
         path: /bazarr
+        pathType: Exact
       - backend:
-          serviceName: transmission
-          servicePort: webui
+          service:
+            name: transmission
+            port:
+              name: webui
         path: /transmission
+        pathType: Exact


### PR DESCRIPTION
This migrates to the now stable v1 API for Ingress. This will suppress the deprecation warning on a cluster at 1.14+