### PR TITLE
Use port number instead of port name in an attempto to fix Traefyk issue

### DIFF
--- a/base/ingress.yaml
+++ b/base/ingress.yaml
@@ -12,39 +12,39 @@ spec:
           service:
             name: emby
             port:
-              name: webui
+              number: 8096
       - path: /jackett
         pathType: Exact
         backend:
           service:
             name: jackett
             port:
-              name: webui
+              number: 9117
       - path: /sonarr
         pathType: Exact
         backend:
           service:
             name: sonarr
             port:
-              name: webui
+              number: 8989
       - path: /radarr
         pathType: Exact
         backend:
           service:
             name: radarr
             port:
-              name: webui
+              number: 7878
       - path: /bazarr
         pathType: Exact
         backend:
           service:
             name: bazarr
             port:
-              name: webui
+              number: 6767
       - path: /transmission
         pathType: Exact
         backend:
           service:
             name: transmission
             port:
-              name: webui
+              number: 9091

--- a/install_armhf.yaml
+++ b/install_armhf.yaml
@@ -600,41 +600,41 @@ spec:
           service:
             name: emby
             port:
-              name: webui
+              number: 8096
         path: /
         pathType: Exact
       - backend:
           service:
             name: jackett
             port:
-              name: webui
+              number: 9117
         path: /jackett
         pathType: Exact
       - backend:
           service:
             name: sonarr
             port:
-              name: webui
+              number: 8989
         path: /sonarr
         pathType: Exact
       - backend:
           service:
             name: radarr
             port:
-              name: webui
+              number: 7878
         path: /radarr
         pathType: Exact
       - backend:
           service:
             name: bazarr
             port:
-              name: webui
+              number: 6767
         path: /bazarr
         pathType: Exact
       - backend:
           service:
             name: transmission
             port:
-              name: webui
+              number: 9091
         path: /transmission
         pathType: Exact

--- a/install_x86_64.yaml
+++ b/install_x86_64.yaml
@@ -600,41 +600,41 @@ spec:
           service:
             name: emby
             port:
-              name: webui
+              number: 8096
         path: /
         pathType: Exact
       - backend:
           service:
             name: jackett
             port:
-              name: webui
+              number: 9117
         path: /jackett
         pathType: Exact
       - backend:
           service:
             name: sonarr
             port:
-              name: webui
+              number: 8989
         path: /sonarr
         pathType: Exact
       - backend:
           service:
             name: radarr
             port:
-              name: webui
+              number: 7878
         path: /radarr
         pathType: Exact
       - backend:
           service:
             name: bazarr
             port:
-              name: webui
+              number: 6767
         path: /bazarr
         pathType: Exact
       - backend:
           service:
             name: transmission
             port:
-              name: webui
+              number: 9091
         path: /transmission
         pathType: Exact


### PR DESCRIPTION
```
time="2022-05-10T08:46:52Z" level=error msg="Skipping service: no endpoints found" serviceName=argocd-server providerName=kubernetes ingress=argocd namespace=argocd servicePort="&ServiceBa 
 time="2022-05-10T08:46:52Z" level=error msg="Skipping service: no endpoints found" servicePort="&ServiceBackendPort{Name:webui,Number:0,}" namespace=htpc providerName=kubernetes ingress=ht 
 time="2022-05-10T08:46:52Z" level=error msg="Skipping service: no endpoints found" namespace=argocd serviceName=argocd-server servicePort="&ServiceBackendPort{Name:http,Number:0,}" provide 
 time="2022-05-10T08:46:52Z" level=error msg="Skipping service: no endpoints found" serviceName=sonarr ingress=htpc namespace=htpc providerName=kubernetes servicePort="&ServiceBackendPort{N 
 time="2022-05-10T08:46:52Z" level=error msg="Skipping service: no endpoints found" serviceName=radarr servicePort="&ServiceBackendPort{Name:webui,Number:0,}" providerName=kubernetes ingres 
 
```