### PR TITLE
Fix: Define htpc-home volume for Kavita deployment

### DIFF
--- a/base/volumes_patch.yaml
+++ b/base/volumes_patch.yaml
@@ -101,3 +101,16 @@ spec:
           path: /opt/htpc
           type: DirectoryOrCreate
         name: htpc-home
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kavita
+spec:
+  template:
+    spec:
+      volumes:
+      - hostPath:
+          path: /opt/htpc
+          type: DirectoryOrCreate
+        name: htpc-home

--- a/install_armhf.yaml
+++ b/install_armhf.yaml
@@ -449,6 +449,11 @@ spec:
           subPath: kavita
       securityContext:
         fsGroup: 1000
+      volumes:
+      - hostPath:
+          path: /opt/htpc
+          type: DirectoryOrCreate
+        name: htpc-home
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/install_x86_64.yaml
+++ b/install_x86_64.yaml
@@ -449,6 +449,11 @@ spec:
           subPath: kavita
       securityContext:
         fsGroup: 1000
+      volumes:
+      - hostPath:
+          path: /opt/htpc
+          type: DirectoryOrCreate
+        name: htpc-home
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This commit addresses an error where the Kavita deployment would fail due to the 'htpc-home' volume not being found.

The `base/volumes_patch.yaml` file was updated to include a patch for the Kavita deployment, ensuring the `htpc-home` hostPath volume (pointing to /opt/htpc) is correctly defined in its `spec.template.spec.volumes`.

Additionally, `make` was run to update the root install manifests.