### PR TITLE
Fix: Update Kavita initContainer to use appsettings.json

### DIFF
--- a/base/kavita/deployment.yaml
+++ b/base/kavita/deployment.yaml
@@ -37,11 +37,14 @@ spec:
           runAsGroup: 1000
         args:
           - |
-            echo 'Customizing config...'
-            if [[ ! -f /config/config.xml ]]; then
-              echo '<Config><BaseUrl>/$(KAVITA)</BaseUrl></Config>'> /config/config.xml
+                echo 'Customizing Kavita config...'
+                if [[ ! -f /config/appsettings.json ]]; then
+                  echo '{"BaseUrl": "$(KAVITA)"}' > /config/appsettings.json
+                  echo 'Kavita appsettings.json created.'
+                else
+                  echo 'Kavita appsettings.json already exists.'
             fi
-            echo 'Done customizing.'
+                echo 'Done customizing Kavita config.'
         volumeMounts:
         - mountPath: /config
           name: htpc-home

--- a/install_armhf.yaml
+++ b/install_armhf.yaml
@@ -430,11 +430,14 @@ spec:
           subPath: media/books/comics
       - args:
         - |
-          echo 'Customizing config...'
-          if [[ ! -f /config/config.xml ]]; then
-            echo '<Config><BaseUrl>/kavita</BaseUrl></Config>'> /config/config.xml
+          echo 'Customizing Kavita config...'
+          if [[ ! -f /config/appsettings.json ]]; then
+            echo '{"BaseUrl": "$(KAVITA)"}' > /config/appsettings.json
+            echo 'Kavita appsettings.json created.'
+          else
+            echo 'Kavita appsettings.json already exists.'
           fi
-          echo 'Done customizing.'
+          echo 'Done customizing Kavita config.'
         command:
         - sh
         - -c

--- a/install_x86_64.yaml
+++ b/install_x86_64.yaml
@@ -430,11 +430,14 @@ spec:
           subPath: media/books/comics
       - args:
         - |
-          echo 'Customizing config...'
-          if [[ ! -f /config/config.xml ]]; then
-            echo '<Config><BaseUrl>/kavita</BaseUrl></Config>'> /config/config.xml
+          echo 'Customizing Kavita config...'
+          if [[ ! -f /config/appsettings.json ]]; then
+            echo '{"BaseUrl": "$(KAVITA)"}' > /config/appsettings.json
+            echo 'Kavita appsettings.json created.'
+          else
+            echo 'Kavita appsettings.json already exists.'
           fi
-          echo 'Done customizing.'
+          echo 'Done customizing Kavita config.'
         command:
         - sh
         - -c


### PR DESCRIPTION
- Modifies the Kavita init container logic to create/check for `appsettings.json` instead of `config.xml`.
- Sets the `BaseUrl` property in `appsettings.json` using the `$(KAVITA)` placeholder to allow runtime configuration via the KAVITA environment variable.
- Applied changes to `base/kavita/deployment.yaml`, `install_armhf.yaml`, and `install_x86_64.yaml`.