### PR TITLE
Setup port forwarding for Transmission

### DIFF
--- a/base/transmission/service.yaml
+++ b/base/transmission/service.yaml
@@ -3,10 +3,19 @@ kind: Service
 metadata:
   name: transmission
 spec:
+  type: LoadBalancer
   ports:
   - port: 9091
     protocol: TCP
     targetPort: 9091
     name: webui
+  - name: torrent-tcp
+    protocol: TCP
+    port: 51413
+    targetPort: 51413
+  - name: torrent-udp
+    protocol: UDP
+    port: 51413
+    targetPort: 51413
   selector:
     run: transmission

--- a/install_armhf.yaml
+++ b/install_armhf.yaml
@@ -172,9 +172,18 @@ spec:
     port: 9091
     protocol: TCP
     targetPort: 9091
+  - name: torrent-tcp
+    port: 51413
+    protocol: TCP
+    targetPort: 51413
+  - name: torrent-udp
+    port: 51413
+    protocol: UDP
+    targetPort: 51413
   selector:
     app: htpc
     run: transmission
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service

--- a/install_x86_64.yaml
+++ b/install_x86_64.yaml
@@ -172,9 +172,18 @@ spec:
     port: 9091
     protocol: TCP
     targetPort: 9091
+  - name: torrent-tcp
+    port: 51413
+    protocol: TCP
+    targetPort: 51413
+  - name: torrent-udp
+    port: 51413
+    protocol: UDP
+    targetPort: 51413
   selector:
     app: htpc
     run: transmission
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
I have updated the Transmission service configuration to support port forwarding.
The following changes were made:
1. Modified `base/transmission/service.yaml` to change the service type to `LoadBalancer` and added ports `51413` for both TCP and UDP.
2. Ran `./update-manifests.sh` to propagate these changes to the architecture-specific install manifests (`install_x86_64.yaml` and `install_armhf.yaml`).

These changes will allow you to set up port forwarding on your router pointing to the k3s node on port 51413.

---
*PR created automatically by Jules for task [7592453670692103892](https://jules.google.com/task/7592453670692103892) started by @fabito*