### PR TITLE
fix(ci): clean up upgrade-apps branch lifecycle

### DIFF
--- a/.github/workflows/upgrade-apps.yaml
+++ b/.github/workflows/upgrade-apps.yaml
@@ -27,9 +27,10 @@ jobs:
 
       - name: Create Pull Request
         if: steps.upgrade.outputs.apps_updated == 'true'
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: ${{ steps.upgrade.outputs.commit_message }}
           title: 'chore(apps): bump to latest versions'
           body: 'This is an automated pull request to upgrade the installed apps.'
           branch: 'feat/automate-app-upgrades'
+          delete-branch: true


### PR DESCRIPTION
## Problem

The automated app-upgrade branch `feat/automate-app-upgrades` was never deleted:

- Repo setting `delete_branch_on_merge` was off (now enabled)
- The `create-pull-request@v3` step didn't set `delete-branch`

After each squash merge the stale branch lingered with a tree identical to master but commits outside master's history. Evidence from PR #61: created Jan 1, force-pushed on the 1st of every month for 9 months before merging, with failures (e.g. the `.sig` tag) silently re-pushed each cycle.

## Changes

- `peter-evans/create-pull-request` v3 (deprecated) → v7
- `delete-branch: true` so the branch is removed when the PR closes/merges
- Stale remote branch deleted (tree was identical to master)
- Repo setting **Automatically delete head branches** enabled via API